### PR TITLE
Argparse enum fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,6 @@
 name: Tests
 
 on:
-  - push
   - pull_request
 
 jobs:
@@ -10,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 src/alttxt.egg-info/
 src/alttxt/__pycache__/
 tests/__pycache__/
+build/

--- a/data/simpson_grammar.json
+++ b/data/simpson_grammar.json
@@ -1,0 +1,31 @@
+{
+  "firstAggregateBy": "None",
+  "firstOverlapDegree": 2,
+  "secondAggregateBy": "None",
+  "secondOverlapDegree": 2,
+  "sortVisibleBy": "Alphabetical",
+  "sortBy": "Cardinality",
+  "filters": {
+    "maxVisible": 3,
+    "minVisible": 0,
+    "hideEmpty": true
+  },
+  "visibleSets": [
+    "Set_School",
+    "Set_Blue_Hair",
+    "Set_Duff_Fan",
+    "Set_Evil",
+    "Set_Male",
+    "Set_Power_Plant"
+  ],
+  "visibleAttributes": [
+    "Age"
+  ],
+  "bookmarkedIntersections": [],
+  "collapsed": [],
+  "plots": {
+    "scatterplots": [],
+    "histograms": [],
+    "wordClouds": []
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,6 @@ show_error_codes = true
 strict_equality = true
 warn_redundant_casts = true
 warn_return_any = true
-warn_unreachable = true
+warn_unreachable = false
 warn_unused_configs = true
 no_implicit_reexport = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,7 @@ alttxt = py.typed
 
 [flake8]
 max-line-length = 160
+inline-quotes = double
+
+[mypy]
+python-version = 3.11.2

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     setup()

--- a/src/alttxt/generic.py
+++ b/src/alttxt/generic.py
@@ -1,9 +1,8 @@
-from alttxt.models import DataModel
-from alttxt.models import GrammarModel
-from alttxt.types_ import FileType
-from alttxt.parser import Parser
 from pathlib import Path
 
+from alttxt.models import DataModel, GrammarModel
+from alttxt.parser import Parser
+from alttxt.types_ import FileType
 
 Model = DataModel | GrammarModel
 

--- a/src/alttxt/main.py
+++ b/src/alttxt/main.py
@@ -1,21 +1,13 @@
 import argparse
 import re
 import sys
-
-from alttxt import phrases
-
-from alttxt.generic import RawData
-from alttxt.generic import Grammar
-
-from alttxt.models import DataModel
-from alttxt.models import GrammarModel
-from alttxt.types_ import Direction
-from alttxt.types_ import Granularity
-from alttxt.types_ import Level
-
 from pathlib import Path
 from typing import Optional
 
+from alttxt import phrases
+from alttxt.generic import Grammar, RawData
+from alttxt.models import DataModel, GrammarModel
+from alttxt.types_ import Direction, Granularity, Level
 
 Model = DataModel | GrammarModel
 
@@ -27,7 +19,7 @@ class AltTxt:
         data_model: Model,
         grammar_model: Model,
         level: Level,
-        granularity: Granularity
+        granularity: Granularity,
     ) -> None:
         self.direction = direction
         self.data_model = data_model
@@ -42,77 +34,93 @@ class AltTxt:
 
     @property
     def text(self) -> str:
-        text_desc = ''
+        text_desc = ""
         match self.level:
             case Level.ZERO.value:
-                text_desc = self.descriptions[f'level_{Level.ZERO.value}'][self.granularity.value]
+                text_desc = self.descriptions[f"level_{Level.ZERO.value}"][
+                    self.granularity.value
+                ]
 
             case Level.ONE.value:
-                text_desc = self.descriptions[f'level_{Level.ONE.value}'][self.granularity.value]
+                text_desc = self.descriptions[f"level_{Level.ONE.value}"][
+                    self.granularity.value
+                ]
                 # text_desc = re.sub(r'{caption}', f'{self.grammar.caption}', text_desc)
                 # text_desc = re.sub(r'{title}', f'{self.grammar.title}', text_desc)
-                text_desc = re.sub(r'\{total\}', f'{sum(self.data_model.count)}', text_desc)
+                text_desc = re.sub(
+                    r"\{total\}", f"{sum(self.data_model.count)}", text_desc
+                )
 
             case Level.TWO.value:
-                text_desc = self.descriptions[f'level_{Level.TWO.value}'][self.granularity.value]
+                text_desc = self.descriptions[f"level_{Level.TWO.value}"][
+                    self.granularity.value
+                ]
 
             case Level.THREE.value:
-                text_desc = self.descriptions[f'level_{Level.THREE.value}'][self.granularity.value]
+                text_desc = self.descriptions[f"level_{Level.THREE.value}"][
+                    self.granularity.value
+                ]
 
             case _:
-                raise TypeError(f'Expected {Level.list()}. Got {self.level}.')
+                raise TypeError(f"Expected {Level.list()}. Got {self.level}.")
 
         return text_desc
 
 
 def main(argv: Optional[list[str]] = None) -> int:
     argv = argv if argv is not None else sys.argv[1:]
-    parser = argparse.ArgumentParser(prog='alttxt', add_help=False)
+    parser = argparse.ArgumentParser(prog="alttxt", add_help=False)
 
     parser.add_argument(
-        '-V', '--version',
-        action='version',
-        version='%(prog)s 0.1',
-        help='Show program version number and exit.',
+        "-V",
+        "--version",
+        action="version",
+        version="%(prog)s 0.1",
+        help="Show program version number and exit.",
     )
     parser.add_argument(
-        '-h', '--help',
-        action='help',
+        "-h",
+        "--help",
+        action="help",
         default=argparse.SUPPRESS,
-        help='Show this help message and exit.',
+        help="Show this help message and exit.",
     )
     parser.add_argument(
-        '--data',
+        "--data",
         required=True,
         type=Path,
-        help='Relative path to data file.',
+        help="Relative path to data file.",
     )
     parser.add_argument(
-        '--grammar',
+        "--grammar",
         required=True,
         type=Path,
-        help='Relative path to grammar file.',
+        help="Relative path to grammar file.",
     )
     parser.add_argument(
-        '--level',
+        "--level",
         type=Level,
-        choices=list(Level), # Enum values here don't work unless listed. Argparser does support using Enum as actions
+        choices=list(
+            Level
+        ),  # Enum values here don't work unless listed. Argparser does support using Enum as actions
         default=Level.ONE.value,
-        help='Semantic level for contextually aware alt-text. Defaults to %(default)s.',
+        help="Semantic level for contextually aware alt-text. Defaults to %(default)s.",
     )
     parser.add_argument(
-        '--granularity',
+        "--granularity",
         type=Granularity,
         choices=list(Granularity),
         default=Granularity.MEDIUM.value,
-        help='Alt-text granularity/specificity. Defaults to %(default)s.',
+        help="Alt-text granularity/specificity. Defaults to %(default)s.",
     )
 
     args = parser.parse_args(argv)
 
     rawdata = RawData(Path(args.data)).model
     grammar = Grammar(Path(args.grammar)).model
-    alttext = AltTxt(Direction.HORIZONTAL, rawdata, grammar, args.level.value, args.granularity)
+    alttext = AltTxt(
+        Direction.HORIZONTAL, rawdata, grammar, args.level.value, args.granularity
+    )
 
     print(alttext.text)
 
@@ -121,5 +129,5 @@ def main(argv: Optional[list[str]] = None) -> int:
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     SystemExit(main())

--- a/src/alttxt/main.py
+++ b/src/alttxt/main.py
@@ -96,14 +96,14 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument(
         '--level',
         type=Level,
-        choices=Level.list(),
+        choices=list(Level), # Enum values here don't work unless listed. Argparser does support using Enum as actions
         default=Level.ONE.value,
         help='Semantic level for contextually aware alt-text. Defaults to %(default)s.',
     )
     parser.add_argument(
         '--granularity',
         type=Granularity,
-        choices=Granularity.list(),
+        choices=list(Granularity),
         default=Granularity.MEDIUM.value,
         help='Alt-text granularity/specificity. Defaults to %(default)s.',
     )
@@ -112,7 +112,7 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     rawdata = RawData(Path(args.data)).model
     grammar = Grammar(Path(args.grammar)).model
-    alttext = AltTxt(Direction.HORIZONTAL, rawdata, grammar, args.level, args.granularity)
+    alttext = AltTxt(Direction.HORIZONTAL, rawdata, grammar, args.level.value, args.granularity)
 
     print(alttext.text)
 

--- a/src/alttxt/models.py
+++ b/src/alttxt/models.py
@@ -1,15 +1,14 @@
-from alttxt.types_ import AggregateBy
-from alttxt.types_ import SortBy
-from alttxt.types_ import SortVisibleBy
 from pydantic import BaseModel
+
+from alttxt.types_ import AggregateBy, SortBy, SortVisibleBy
 
 
 class DataModel(BaseModel):
     membs: list[frozenset[str]]
     count: list[int]
-    sets:  list[str]
+    sets: list[str]
     sizes: dict[str, int]
-    devs:  list[float]
+    devs: list[float]
 
 
 class FilterModel(BaseModel):

--- a/src/alttxt/phrases.py
+++ b/src/alttxt/phrases.py
@@ -1,77 +1,58 @@
 DESCRIPTIONS = {
-    'level_0': {
-        'Low':
-            'The following figure presents an UpSet plot, an alternative '
-            'state-of-the-art data visualization technique for the visual '
-            'representation of intersecting sets and their membership.',
-
-        'Medium':
-            'The following figure presents an UpSet plot, an alternative '
-            'state-of-the-art data visualization technique for the visual '
-            'representation of intersecting sets and their membership. '
-            'An UpSet plot arranges your co-occurring, interlocking '
-            'variables into sets and shows a bar chart of their '
-            'unconditional frequency count at the top.',
-
-        'High':
-            'The following figure presents an UpSet plot, an alternative '
-            'state-of-the-art data visualization technique for the visual '
-            'representation of intersecting sets and their membership.'
-            'An UpSet plot arranges your co-occurring, interlocking '
-            'variables into sets and shows a bar chart of their '
-            'unconditional frequency count at the top sorted from '
-            'left to right. A matrix layout is shown underneath. Each '
-            'row of the matrix corresponds to a set and bar charts to '
-            'the left of it show the number of elements within that set.'
+    "level_0": {
+        "Low": "The following figure presents an UpSet plot, an alternative "
+        "state-of-the-art data visualization technique for the visual "
+        "representation of intersecting sets and their membership.",
+        "Medium": "The following figure presents an UpSet plot, an alternative "
+        "state-of-the-art data visualization technique for the visual "
+        "representation of intersecting sets and their membership. "
+        "An UpSet plot arranges your co-occurring, interlocking "
+        "variables into sets and shows a bar chart of their "
+        "unconditional frequency count at the top.",
+        "High": "The following figure presents an UpSet plot, an alternative "
+        "state-of-the-art data visualization technique for the visual "
+        "representation of intersecting sets and their membership."
+        "An UpSet plot arranges your co-occurring, interlocking "
+        "variables into sets and shows a bar chart of their "
+        "unconditional frequency count at the top sorted from "
+        "left to right. A matrix layout is shown underneath. Each "
+        "row of the matrix corresponds to a set and bar charts to "
+        "the left of it show the number of elements within that set.",
     },
-    'level_1': {
-        'Low':
-            'This an UpSet plot of {caption} that plots {title}. A total '
-            'of {total} co-occuring variables are displayed. They read '
-            'from left to right as: {set_name_1}, {set_name_2}, and '
-            '{set_name_3}.',
-
-        'Medium':
-            'This an UpSet plot of {caption} that plots {title}. A total '
-            'of {total} co-occuring variables are displayed. They read '
-            'from left to right as: {listable_sets}. Visually, the plot is '
-            'comprised of three components. '
-            'Component 1 -- interlocking set sizes representing {caption} '
-            'is plotted on the y-axis from {y_min} to {y_max} '
-            'in increments of {y_inc}. Underneath is a graphical table of '
-            'set membership showing a total of {total} {caption} observed '
-            'across {universal_set_size} different patterns. To the left is '
-            'a smaller bar chart showing the unconditional frequency '
-            'count of each set name plotted on the x-axis from values '
-            'from {set_size_min} to {set_size_max} in increments of '
-            '{set_size_inc}. {set_name} are {set_name_1}, {set_name_2}, '
-            '{set_name_3}, and {set_name_n}.',
-
-        'High':
-            'This an UpSet plot of {caption} that plots {title}. A total '
-            'of {total} co-occuring variables are displayed. They read '
-            'from top to bottom as: {set_name_1}, {set_name_2}, and '
-            '{set_name_n}. Visually, the plot is comprised of three components. '
-            'Component 1 -- interlocking set sizes representing {caption} '
-            'is plotted on the y-axis from {y_min} to {y_max} '
-            'in increments of {y_inc}. Underneath is a graphical table of '
-            'set membership showing a total of {total} {caption} observed '
-            'across {universal_set_size} different patterns. To the left is '
-            'a smaller bar chart showing the unconditional frequency '
-            'count of each {set_name} plotted on the x-axis from values '
-            'from {set_size_min} to {set_size_max} in increments of '
-            '{set_size_inc}. {set_name} are {set_name_1}, {set_name_2}, '
-            '{set_name_3}, and {set_name_n}.',
+    "level_1": {
+        "Low": "This an UpSet plot of {caption} that plots {title}. A total "
+        "of {total} co-occuring variables are displayed. They read "
+        "from left to right as: {set_name_1}, {set_name_2}, and "
+        "{set_name_3}.",
+        "Medium": "This an UpSet plot of {caption} that plots {title}. A total "
+        "of {total} co-occuring variables are displayed. They read "
+        "from left to right as: {listable_sets}. Visually, the plot is "
+        "comprised of three components. "
+        "Component 1 -- interlocking set sizes representing {caption} "
+        "is plotted on the y-axis from {y_min} to {y_max} "
+        "in increments of {y_inc}. Underneath is a graphical table of "
+        "set membership showing a total of {total} {caption} observed "
+        "across {universal_set_size} different patterns. To the left is "
+        "a smaller bar chart showing the unconditional frequency "
+        "count of each set name plotted on the x-axis from values "
+        "from {set_size_min} to {set_size_max} in increments of "
+        "{set_size_inc}. {set_name} are {set_name_1}, {set_name_2}, "
+        "{set_name_3}, and {set_name_n}.",
+        "High": "This an UpSet plot of {caption} that plots {title}. A total "
+        "of {total} co-occuring variables are displayed. They read "
+        "from top to bottom as: {set_name_1}, {set_name_2}, and "
+        "{set_name_n}. Visually, the plot is comprised of three components. "
+        "Component 1 -- interlocking set sizes representing {caption} "
+        "is plotted on the y-axis from {y_min} to {y_max} "
+        "in increments of {y_inc}. Underneath is a graphical table of "
+        "set membership showing a total of {total} {caption} observed "
+        "across {universal_set_size} different patterns. To the left is "
+        "a smaller bar chart showing the unconditional frequency "
+        "count of each {set_name} plotted on the x-axis from values "
+        "from {set_size_min} to {set_size_max} in increments of "
+        "{set_size_inc}. {set_name} are {set_name_1}, {set_name_2}, "
+        "{set_name_3}, and {set_name_n}.",
     },
-    'level_2': {
-        'Low':
-            'In figure {caption}, {set_name}',
-        'Medium': '',
-        'High': ''
-    },
-    'level_3': {
-        'Low': '',
-        'Medium': '',
-        'High': ''
-    }
+    "level_2": {"Low": "In figure {caption}, {set_name}", "Medium": "", "High": ""},
+    "level_3": {"Low": "", "Medium": "", "High": ""},
 }

--- a/src/alttxt/types_.py
+++ b/src/alttxt/types_.py
@@ -1,5 +1,5 @@
 import re
-from enum import auto, Enum
+from enum import Enum, auto
 from typing import Any
 
 
@@ -18,42 +18,42 @@ class FileType(Listable):
 
 
 class Granularity(Listable):
-    LOW = 'Low'
-    MEDIUM = 'Medium'
-    HIGH = 'High'
+    LOW = "Low"
+    MEDIUM = "Medium"
+    HIGH = "High"
 
     def __str__(self) -> str:
         return self.value
 
 
 class Level(Listable):
-    ZERO = '0'
-    ONE = '1'
-    TWO = '2'
-    THREE = '3'
+    ZERO = "0"
+    ONE = "1"
+    TWO = "2"
+    THREE = "3"
 
     def __str__(self) -> str:
         return self.value
 
 
 class AggregateBy(Listable):
-    DEGREE = 'Degree'
-    SETS = 'Sets'
-    DEVIATION = 'Deviation'
-    OVERLAPS = 'Overlaps'
-    NONE = 'None'
+    DEGREE = "Degree"
+    SETS = "Sets"
+    DEVIATION = "Deviation"
+    OVERLAPS = "Overlaps"
+    NONE = "None"
 
 
 class SortBy(Listable):
-    DEGREE = 'Degree'
-    CARDINALITY = 'Cardinality'
-    DEVIATION = 'Deviation'
+    DEGREE = "Degree"
+    CARDINALITY = "Cardinality"
+    DEVIATION = "Deviation"
 
 
 class SortVisibleBy(Listable):
-    ALPHABETICAL = 'Alphabetical'
-    ASCENDING = 'Ascending'
-    DESCENDING = 'Descending'
+    ALPHABETICAL = "Alphabetical"
+    ASCENDING = "Ascending"
+    DESCENDING = "Descending"
 
 
 class Direction(Listable):
@@ -72,4 +72,4 @@ class Dict(dict[Any, Any]):
         self[self.snake_case(attr)] = value
 
     def snake_case(self, attr):
-        return re.sub(r'(?<!^)(?=[A-Z])', '_', attr).lower()
+        return re.sub(r"(?<!^)(?=[A-Z])", "_", attr).lower()

--- a/tests/test_alttxt.py
+++ b/tests/test_alttxt.py
@@ -1,10 +1,6 @@
 import pytest
-from alttxt import models
-from alttxt import parser
-from alttxt import types_
-from alttxt import generic
-from alttxt import main
-from alttxt import phrases
+
+from alttxt import generic, main, models, parser, phrases, types_
 
 
 def test_models() -> bool:

--- a/tox.ini
+++ b/tox.ini
@@ -1,29 +1,53 @@
 [tox]
-minversion = 3.10.0
-envlist = py310, py311, flake8, mypy
-isolated_build = true
-
-[gh-actions]
-python =
-    3.10: py310, mypy, flake8
-    3.11: py311
+envlist = lint, type, test
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}
 deps =
-    -r{toxinidir}/requirements_dev.txt
+    # Common dependencies
+    flake8<6
+
+[testenv:lint]
+skipsdist = true
+skip_install = true
+basepython = python3
+deps =
+    {[testenv]deps}
+    flake8-black
+    flake8-quotes
+    flake8-bugbear
 commands =
-    pytest --basetemp={envtmpdir}
+    flake8 --extend-exclude=migrations setup.py src/alttxt
 
-[testenv:flake8]
-basepython = python3.10
-deps = flake8
-commands = flake8 src tests
-
-[testenv:mypy]
-basepython = python3.10
+[testenv:type]
+# we need dependencies to be installed
+skipsdist = true
+skip_install = true
+usedevelop = true
 deps =
-    -r{toxinidir}/requirements_dev.txt
-commands = mypy src
+    {[testenv]deps}
+    mypy
+    django-stubs
+    djangorestframework-stubs
+commands =
+    mypy setup.py src/alttxt
+setenv =
+    DJANGO_CONFIGURATION = TestingConfiguration
 
+[testenv:test]
+deps =
+    {[testenv]deps}
+    pytest
+    pytest-cov
+commands =
+    pytest {posargs}
+
+[testenv:format]
+skipsdist = true
+skip_install = true
+basepython = python3
+deps =
+    {[testenv]deps}
+    black
+commands =
+    # Run Black to format the code
+    black {posargs} setup.py src/alttxt


### PR DESCRIPTION
### Does this PR close any open issues?
Closes no issues

### Give a longer description of what this PR addresses and why it's needed
Adds: 
- `simpsons_grammar.json` to accompany `simpsons.json` data file.

Fixes:
- `argparser` does not support `List[Enum]` values for `choices`. The fix is to create a list of the enum values instead via `list(Enum)`.
- TypeError due to enum values being passed to `AltText` as Objects rather than their value

Refactors:
- Tox test suite: Adds tests for `lint`, `type`, and `test`. Adds action `format` to format files in accordance with flake8/black
- GitHub Actions: Removes python 3.10 tests and only tests on `pull_request`