### PR TITLE
Combined level 1 and level 2 descriptions as default. User can still …

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Transactions on Visualization & Computer Graphics (Proc. IEEE VIS).
 6. Install the alttxt module in development mode with `pip install -e .`
 
 
-To run the program with the example data, run `python [path/to/alttxt directory] --data ../../data/movie_data_card_sort.json --level 2 --verbosity medium`
+To run the program with the example data, run `python [path/to/alttxt directory] --data ../../data/movie_data_card_sort.json --verbosity medium`
 Level and granularity can be changed to any of the options listed in [Command Line Options](#command-line-options).
 Here is an example command: 
-    For unix/macOS: `python3 src/alttxt --data data/movie_data_dev_sort.json --level 2 --verbosity medium`
-    For Windows: `python src/alttxt --data data/movie_data_dev_sort.json --level 2 --verbosity medium`
+    For unix/macOS: `python3 src/alttxt --data data/movie_data_dev_sort.json --verbosity medium`
+    For Windows: `python src/alttxt --data data/movie_data_dev_sort.json --verbosity medium`
 
 ## Local Testing
 
@@ -42,7 +42,7 @@ To run the entire suite of tests at once, use `tox`.
 | `-h`, `--help`         | Show information on each command and exit.                                                      |
 | `-V`, `--version`      | Show the program version number and exit.                                                       |
 | `-D`, `--data`         | (Required) Relative path to data file.                                                          |
-| `-l`, `--level`        | Semantic level. Defaults to `1`. Options are: `1`, `2`, and `3`. `4` TBA.                       |
+| `-l`, `--level`        | Semantic level. Defaults to a combination of all levels. Options are: `1`, `2`.                 |
 | `-v`, `--verbosity`    | Alt-text verbosity. Defaults to `medium`. Options: `low`, `medium`, `high`.                     |
 | `-e`, `--explain-upset`| Whether to explain UpSet plots generally. Defaults to `none`. Options: `none`, `simple`, `full`.|
 | `-t`, `--title`        | A title for the plot; used in some generations. Defaults to `has no title`.                     |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ no_implicit_reexport = true
 
 [project]
 name = "upset-alttxt"
-version = "0.1.10"
+version = "0.1.11"
 description = "Generates alt text for UpSet plots"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/alttxt/__main__.py
+++ b/src/alttxt/__main__.py
@@ -44,7 +44,7 @@ def main(argv: Optional["list[str]"] = None) -> int:
         "--level",
         type=Level,
         choices=list(Level),
-        default=Level.ONE,
+        default=Level.DEFAULT,
         help="Semantic level. Defaults to %(default)s.",
     )
     parser.add_argument(

--- a/src/alttxt/enums.py
+++ b/src/alttxt/enums.py
@@ -31,6 +31,7 @@ class Level(Listable):
     """
     ONE = "1"
     TWO = "2"
+    DEFAULT = "default"
 
     def __str__(self) -> str:
         return self.value

--- a/src/alttxt/generator.py
+++ b/src/alttxt/generator.py
@@ -49,6 +49,14 @@ class AltTxtGen:
             # L2 splits generation by sort type of the plot
             text_desc += self.descriptions["level_2"]\
                     [self.verbosity.value][self.grammar.sort_by]
+            
+        elif self.level == Level.DEFAULT:
+            # Default level is combination of L1 and L2
+            text_desc += self.descriptions["level_1"][self.verbosity.value]
+            text_desc += " "
+            text_desc += self.descriptions["level_2"]\
+                    [self.verbosity.value][self.grammar.sort_by]
+            
         else:
             raise TypeError(f"Expected {Level.list()}. Got {self.level}.")
 


### PR DESCRIPTION
…use --level to see description of a particular level

### Does this PR close any open issues?
Closes #

### Give a longer description of what this PR addresses and why it's needed
This PR combines level 1 and level 2 alternative text descriptions as default. Users can still use the --level parameter to see level-specific descriptions.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...