### PR TITLE
triuncated set names having large set names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ no_implicit_reexport = true
 
 [project]
 name = "upset-alttxt"
-version = "0.2.7"
+version = "0.2.8"
 description = "Generates alt text for UpSet plots"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/alttxt/parser.py
+++ b/src/alttxt/parser.py
@@ -147,6 +147,10 @@ class Parser:
             name: str = item.get("elementName", self.default_field)
             if name.lower() == "unincluded":
                 name = "the empty intersection"
+            else:
+            # Replace underscores with hyphens if underscores are present
+                name = name.replace('_', '-') if '_' in name else name
+            
             # size
             size: int = int(item.get("size", self.default_field))
             # Deviation - rounded to 2 decimals
@@ -165,7 +169,7 @@ class Parser:
             setMembership = {key[4:] if key.startswith("Set_") else key: value for key, value in item.get("setMembership", {}).items() if value == "Yes"}
 
             # Only store the keys (set names) that have "Yes" as their value
-            yes_sets = {key for key, value in setMembership.items() if value == "Yes"}
+            yes_sets = {key.replace('_','-') for key, value in setMembership.items() if value == "Yes"}
 
             subsets.append(Subset(name=name, size=size, dev=dev, degree=degree, classification=classification, setMembership=yes_sets))
 
@@ -226,7 +230,7 @@ class Parser:
         #     # must be done after prev steps
             if set_name.startswith("Set_"):
                 set_name = set_name[4:]
-            sets_.append(set_name)
+            sets_.append(set_name.replace('_', '-'))
 
         
         # Initialize deviations
@@ -297,7 +301,7 @@ class Parser:
                 # visible_set_sizes expects "Thriller", rather than "Set_Thriller"
                 name = set_name
                 if name.startswith("Set_"):
-                    name = name[4:]
+                    name = name[4:].replace('_', '-')
 
                 visible_set_sizes[name] = grammar["allSets"][all_set_names.index(set_name)]["size"]
             else:
@@ -316,7 +320,7 @@ class Parser:
         # Remove the 'Set_' prefix from each visible set name, if extant
         for i in range(len(visible_sets)):
             if visible_sets[i].startswith("Set_"):
-                visible_sets[i] = visible_sets[i][4:]
+                visible_sets[i] = visible_sets[i][4:].replace('_', '-')
 
         grammar_model = GrammarModel(
             first_aggregate_by=first_aggregate_by,

--- a/src/alttxt/tokenmap.py
+++ b/src/alttxt/tokenmap.py
@@ -609,7 +609,7 @@ class TokenMap:
 
         # 'largest_subset' now holds the subset with more than one set that has the largest size
         if largest_subset is not None:
-            return self.truncate_string(largest_subset.name, 15), largest_subset.size
+            return self.truncate_separately(largest_subset.name), largest_subset.size
         else:
             return None, 0
 
@@ -628,7 +628,8 @@ class TokenMap:
 
         # 'smallest_subset' now holds the subset with more than one set that has the smallest size
         if smallest_subset is not None:
-            return smallest_subset.name, smallest_subset.size
+            return self.truncate_separately(smallest_subset.name), smallest_subset.size
+        
         else:
             return None, 0
         

--- a/src/alttxt/tokenmap.py
+++ b/src/alttxt/tokenmap.py
@@ -54,7 +54,7 @@ class TokenMap:
             # Set description as set name
             "set_description": f"{self.grammar.metaData.items.lower()}" if self.grammar.metaData.items else "elements",
             # largest by what factor
-            "largest_factor": f" {self.sort_subsets_by_key(SubsetField.SIZE, True)[0].name} is the largest by a factor of {self.calculate_largest_factor()}." if self.calculate_largest_factor() >= 2 else "",
+            "largest_factor": f" {self.truncate_separately(self.sort_subsets_by_key(SubsetField.SIZE, True)[0].name)} is the largest by a factor of {self.calculate_largest_factor()}." if self.calculate_largest_factor() >= 2 else "",
             # set intersection categorization text based on intersection type and size
             "empty_set_presence": f" The empty intersection is present with a size of {self.get_empty_intersection_size()}." if (self.categorize_subsets().get('the empty intersection') and self.categorize_subsets().get('the empty intersection')!='largest_data_region') else "",
             "all_set_presence": f" An all set intersection is present with a size of {self.get_all_set_intersection_size()}." if self.get_all_set_intersection_size()!= None else f" An all set intersection is not present.",
@@ -78,7 +78,7 @@ class TokenMap:
             # List of sorted visible set names and sizes
             "list_sorted_visible_sets": self.list_sorted_visible_sets,
             # Largest visible set name
-            "max_set_name": self.sort_visible_sets()[0][0],
+            "max_set_name": self.truncate_string(self.sort_visible_sets()[0][0], 15),
             # Largest visible set size
             "max_set_size": self.sort_visible_sets()[0][1],
             # max set percentage
@@ -86,7 +86,7 @@ class TokenMap:
                 self.sort_visible_sets()[0][0]
             ),
             # Smallest visible set name
-            "min_set_name": self.sort_visible_sets()[-1][0],
+            "min_set_name": self.truncate_string(self.sort_visible_sets()[-1][0], 15),
             # Smallest visible set size
             "min_set_size": self.sort_visible_sets()[-1][1],
             # min set percentage
@@ -393,8 +393,10 @@ class TokenMap:
         for i in range(0, n):
             if i >= len(sort):
                 break
-
-            result += f"{sort[i].name} ({sort[i].size}), "
+            
+            formatted_names = self.truncate_separately(sort[i].name)
+            result += f"{formatted_names} ({sort[i].size}), "
+        
             if i == n - 2:
                 result += "and "
 
@@ -525,13 +527,13 @@ class TokenMap:
         # Format the sorted sets into the desired string format
         if len(sorted_by_size) > 1:
             set_strings = [
-                f"{set_name} with {size}" for set_name, size in sorted_by_size[:-1]
+                f"{self.truncate_string(set_name, 15)} with {size}" for set_name, size in sorted_by_size[:-1]
             ]
-            last_set_string = f"{sorted_by_size[-1][0]} with {sorted_by_size[-1][1]}"
+            last_set_string = f"{self.truncate_string(sorted_by_size[-1][0], 15)} with {sorted_by_size[-1][1]}"
             return ", ".join(set_strings) + ", and " + last_set_string
         elif sorted_by_size:
             # If there is only one set after excluding the largest
-            return f"{sorted_by_size[0][0]} with {sorted_by_size[0][1]}"
+            return f"{self.truncate_string(sorted_by_size[0][0], 15)} with {sorted_by_size[0][1]}"
         else:
             # If there are no sets to list (empty or only one set was visible initially)
             return "No sets to list"
@@ -578,10 +580,10 @@ class TokenMap:
         maxmin_set_count = 0
 
         # Total number of non-empty intersections
-        total_non_empty = sum(1 for subset in self.data.all_subsets if subset.size > 0)
+        total_non_empty = sum(1 for subset in self.data.subsets if subset.size > 0)
 
         # Iterate through all subsets
-        for subset in self.data.all_subsets:
+        for subset in self.data.subsets:
             if subset.size > 0:  # Check only non-empty subsets
                 if maxmin_sized_set_name in subset.name:
                     maxmin_set_count += 1
@@ -607,7 +609,7 @@ class TokenMap:
 
         # 'largest_subset' now holds the subset with more than one set that has the largest size
         if largest_subset is not None:
-            return largest_subset.name, largest_subset.size
+            return self.truncate_string(largest_subset.name, 15), largest_subset.size
         else:
             return None, 0
 
@@ -907,7 +909,7 @@ class TokenMap:
         most_dominant_set = most_common_sets[0][0]
         second_most_dominant_set = most_common_sets[1][0] if len(most_common_sets) > 1 else None
 
-        return f"{most_dominant_set}, and {second_most_dominant_set}"
+        return f"{self.truncate_string(most_dominant_set, 15)}, and {self.truncate_string(second_most_dominant_set, 15)}"
 
     def find_sets_in_large_subsets(self):
 
@@ -939,11 +941,11 @@ class TokenMap:
     
          # Formatting the return value based on the size of the sets list
         if len(sets) == 2:
-            return f"{sets[0]} and {sets[1]}"
+            return f"{self.truncate_string(sets[0], 15)} and {self.truncate_string(sets[1], 15)}"
         elif len(sets) > 2:
-            return ', '.join(sets[:-1]) + ', and ' + sets[-1]
+            return ', '.join(self.truncate_string(sets[:-1], 15)) + ', and ' + self.truncate_string(sets[-1], 15)
         else:
-            return sets
+            return self.truncate_string(sets, 15)
     
 
     def get_all_set_position(self):
@@ -978,6 +980,24 @@ class TokenMap:
         else:
             return ""
 
+
+    def truncate_string(self, original_string, length):
+            # Ensure the length is not greater than the string's length
+        if original_string.lower().startswith('just '):
+            original_string = original_string[5:]
+        if original_string.lower().startswith('and '):
+            original_string = original_string[4:]
+
+        if length < len(original_string):
+            return original_string[:length]
+        return original_string
+    
+    def truncate_separately(self, sorted_subset):
+        truncated_names = [self.truncate_string(name, 15) for name in sorted_subset.split(', ')]
+        formatted_names = ", ".join(truncated_names[:-1]) + ", and " + truncated_names[-1] if len(truncated_names) > 1 else "Just " + truncated_names[0]
+
+        return formatted_names
+    
 
 
 

--- a/src/alttxt/tokenmap.py
+++ b/src/alttxt/tokenmap.py
@@ -19,6 +19,7 @@ class TokenMap:
     it is not responsible for the actual substitution of tokens
     or the overall generation of the text description.
     """
+    TRUNCATION_LENGTH = 15  # Global constant for truncation length
 
     def __init__(
         self, data: DataModel, grammar: GrammarModel, title: Optional[str] = None
@@ -78,7 +79,7 @@ class TokenMap:
             # List of sorted visible set names and sizes
             "list_sorted_visible_sets": self.list_sorted_visible_sets,
             # Largest visible set name
-            "max_set_name": self.truncate_string(self.sort_visible_sets()[0][0], 15),
+            "max_set_name": self.truncate_string(self.sort_visible_sets()[0][0]),
             # Largest visible set size
             "max_set_size": self.sort_visible_sets()[0][1],
             # max set percentage
@@ -86,7 +87,7 @@ class TokenMap:
                 self.sort_visible_sets()[0][0]
             ),
             # Smallest visible set name
-            "min_set_name": self.truncate_string(self.sort_visible_sets()[-1][0], 15),
+            "min_set_name": self.truncate_string(self.sort_visible_sets()[-1][0]),
             # Smallest visible set size
             "min_set_size": self.sort_visible_sets()[-1][1],
             # min set percentage
@@ -527,13 +528,13 @@ class TokenMap:
         # Format the sorted sets into the desired string format
         if len(sorted_by_size) > 1:
             set_strings = [
-                f"{self.truncate_string(set_name, 15)} with {size}" for set_name, size in sorted_by_size[:-1]
+                f"{self.truncate_string(set_name)} with {size}" for set_name, size in sorted_by_size[:-1]
             ]
-            last_set_string = f"{self.truncate_string(sorted_by_size[-1][0], 15)} with {sorted_by_size[-1][1]}"
+            last_set_string = f"{self.truncate_string(sorted_by_size[-1][0])} with {sorted_by_size[-1][1]}"
             return ", ".join(set_strings) + ", and " + last_set_string
         elif sorted_by_size:
             # If there is only one set after excluding the largest
-            return f"{self.truncate_string(sorted_by_size[0][0], 15)} with {sorted_by_size[0][1]}"
+            return f"{self.truncate_string(sorted_by_size[0][0])} with {sorted_by_size[0][1]}"
         else:
             # If there are no sets to list (empty or only one set was visible initially)
             return "No sets to list"
@@ -910,7 +911,7 @@ class TokenMap:
         most_dominant_set = most_common_sets[0][0]
         second_most_dominant_set = most_common_sets[1][0] if len(most_common_sets) > 1 else None
 
-        return f"{self.truncate_string(most_dominant_set, 15)}, and {self.truncate_string(second_most_dominant_set, 15)}"
+        return f"{self.truncate_string(most_dominant_set)}, and {self.truncate_string(second_most_dominant_set)}"
 
     def find_sets_in_large_subsets(self):
 
@@ -942,11 +943,11 @@ class TokenMap:
     
          # Formatting the return value based on the size of the sets list
         if len(sets) == 2:
-            return f"{self.truncate_string(sets[0], 15)} and {self.truncate_string(sets[1], 15)}"
+            return f"{self.truncate_string(sets[0])} and {self.truncate_string(sets[1])}"
         elif len(sets) > 2:
-            return ', '.join(self.truncate_string(sets[:-1], 15)) + ', and ' + self.truncate_string(sets[-1], 15)
+            return ', '.join(self.truncate_string(sets[:-1])) + ', and ' + self.truncate_string(sets[-1])
         else:
-            return self.truncate_string(sets, 15)
+            return self.truncate_string(sets)
     
 
     def get_all_set_position(self):
@@ -982,19 +983,36 @@ class TokenMap:
             return ""
 
 
-    def truncate_string(self, original_string, length):
+    def truncate_string(self, original_string):
             # Ensure the length is not greater than the string's length
         if original_string.lower().startswith('just '):
             original_string = original_string[5:]
         if original_string.lower().startswith('and '):
             original_string = original_string[4:]
 
-        if length < len(original_string):
-            return original_string[:length]
+        if TokenMap.TRUNCATION_LENGTH < len(original_string):
+            return original_string[:TokenMap.TRUNCATION_LENGTH]
         return original_string
     
     def truncate_separately(self, sorted_subset):
-        truncated_names = [self.truncate_string(name, 15) for name in sorted_subset.split(', ')]
+        
+        """
+        Splits a string containing multiple set names separated by commas,
+        truncates each name to a maximum length defined by TokenMap.TRUNCATION_LENGTH,
+        and formats them into a single string.
+
+        Initially for convenience to truncate, we cut down 'and' and 'Just' from the subset name in the truncate_string function.
+        In this function, if the subset contains multiple set names, they are joined into a formatted string
+        with commas separating all but the last two names, which are separated by ", and".
+        If the subset contains only one set name, it prefixes the name with "Just".
+
+        Parameters:
+        sorted_subset (str): A comma-separated string of set names.
+
+        Returns:
+        str: A string of formatted and truncated set names.
+        """
+        truncated_names = [self.truncate_string(name) for name in sorted_subset.split(', ')]
         formatted_names = ", ".join(truncated_names[:-1]) + ", and " + truncated_names[-1] if len(truncated_names) > 1 else "Just " + truncated_names[0]
 
         return formatted_names


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #46 

### Give a longer description of what this PR addresses and why it's needed
The PR truncates the long set names to 15 . It also replaces underscores with Hyphens. Example:

**Intersection Properties (previous)**
The plot is sorted by size in descending order. There are 15 non-empty intersections, all of which are shown in the plot. The largest 5 intersections are ALL_X_translucens_pv_cerealis_strain_CFBP_2541_NZ_CM003052, ALL_X_campestris_pv_campestris_str_CN14_NZ_CP017317, ALL_X_citri_subsp_citri_UI6_NZ_CP008992, and ALL_X_oryzae_pv_oryzae_strain_YN24_NZ_CP018089 (2306), Just ALL_X_translucens_pv_cerealis_strain_CFBP_2541_NZ_CM003052 (682), Just ALL_X_oryzae_pv_oryzae_strain_YN24_NZ_CP018089 (654), Just ALL_X_citri_subsp_citri_UI6_NZ_CP008992 (594), and Just ALL_X_campestris_pv_campestris_str_CN14_NZ_CP017317 (586).


**Intersection Properties (After Truncation and Replacing Underscore)**
The plot is sorted by size in descending order. There are 15 non-empty intersections, all of which are shown in the plot. The largest 5 intersections are ALL-X-transluce, ALL_X_campestri, ALL_X_citri_sub,  and ALL_X_oryzae_pv  (2306), Just  ALL_X_transluce (682), Just ALL_X_oryzae_pv (654), Just  ALL_X_citri_sub (594), and Just  ALL_X_campestri (586).

### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [ ] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
