### PR TITLE
Fix large set name truncation error

### DIFF
--- a/data/movies_updated_v0.3.0.json
+++ b/data/movies_updated_v0.3.0.json
@@ -3,8 +3,8 @@
     "description": "",
     "sets": "",
     "items": "",
-    "caption": "[Caption]",
-    "title": "[Title]"
+    "caption": null,
+    "title": null
   },
   "horizontal": false,
   "firstAggregateBy": "None",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ no_implicit_reexport = true
 
 [project]
 name = "upset-alttxt"
-version = "0.2.9"
+version = "0.3.0"
 description = "Generates alt text for UpSet plots"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/alttxt/models.py
+++ b/src/alttxt/models.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from alttxt.enums import AggregateBy, SortBy, SortVisibleBy, SortOrder, IntersectionType
 from pydantic import BaseModel
 
@@ -48,9 +49,11 @@ class PlotModel(BaseModel):
 
 
 class MetaDataModel(BaseModel):
-    description: str
-    sets: str
-    items: str
+    title: Optional[str] = ""
+    caption: Optional[str] = ""
+    description: Optional[str] = ""
+    sets: Optional[str] = ""
+    items: Optional[str] = ""
 
 
 class GrammarModel(BaseModel):

--- a/src/alttxt/tokenmap.py
+++ b/src/alttxt/tokenmap.py
@@ -940,12 +940,12 @@ class TokenMap:
         else:
             for sm in second_largest_sets:
                 sets.append(sm)
-    
+
          # Formatting the return value based on the size of the sets list
         if len(sets) == 2:
             return f"{self.truncate_string(sets[0])} and {self.truncate_string(sets[1])}"
         elif len(sets) > 2:
-            return ', '.join(self.truncate_string(sets[:-1])) + ', and ' + self.truncate_string(sets[-1])
+            return self.truncate_separately(', '.join(sets))
         else:
             return self.truncate_string(sets)
     


### PR DESCRIPTION
### Does this PR close any open issues?
Closes none

### Give a longer description of what this PR addresses and why it's needed
Fixes a thrown error while the setnames were being truncated. The error is only thrown when the there are 3 or more equally large intersections. In the case of movies, there are 2 or 1 significantly larger intersections, and so this error never occurs.

This was introduced in https://github.com/visdesignlab/upset-alt-txt-gen/commit/1d7f89334418ee7e62f1ad89e7c8c4aef326791a but never had a release made for the commit. This is why the issue just now arose.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
