### PR TITLE
Add polynomial fit and residual comparison across types

### DIFF
--- a/src/alttxt/enums.py
+++ b/src/alttxt/enums.py
@@ -135,4 +135,6 @@ class IntersectionTrend(Listable):
     to the MultiNet implementation's export format.
     """
     DRASTIC = "drastically"
-    MODERATE = "moderately"
+    RAPID = "rapidly"
+    QUICK = "quickly"
+    STEADY = "steadily"

--- a/src/alttxt/tokenmap.py
+++ b/src/alttxt/tokenmap.py
@@ -775,8 +775,12 @@ class TokenMap:
         linear_fit = slope * x + intercept
         linear_residuals = np.sum((y - linear_fit) ** 2)
 
+        # polynomial (quadratic) fit
+        fit = np.polyfit(x, y, 2, full=True)
+        quadratic_residuals = fit[1][0]
+
         # exponential fit
-        popt, _ = curve_fit(lambda x, a, beta, c: a*np.exp(-b*x)+c, x, y, 
+        popt, _ = curve_fit(lambda x, a, beta, c: a*np.exp(-beta*x)+c, x, y,
                             p0=[max(y), 0.1, min(y)],
                             bounds=([0, 0, 0], [np.inf, np.inf, np.inf]),
                             maxfev=5000)
@@ -789,10 +793,6 @@ class TokenMap:
             exponential_residuals = np.sum((y - y_fit_interpolated) ** 2)
         else:
             exponential_residuals = np.inf
-
-        # polynomial fit
-        fit = np.polyfit(x, y, 2, full=True)
-        quadratic_residuals = fit[1][0]
 
         if exponential_residuals < linear_residuals and exponential_residuals < quadratic_residuals:
             if beta > 0.8:

--- a/src/alttxt/tokenmap.py
+++ b/src/alttxt/tokenmap.py
@@ -749,50 +749,61 @@ class TokenMap:
             return IndividualSetSize.DIVERGINGABIT.value
         else:
             return IndividualSetSize.IDENTICAL.value
-        
 
     def calculate_change_trend(self):
         """
-        Performs non-linear regression using an exponential decay model
-        Calculates an array of optimal values for parameters a (amplitude), b (decay rate), and c (asymptote)
-        Returns the intersection trend type based on the decay rate (b)
+        Analyzes the trend of changes in intersection sizes and classifies the trend.
+
+        This method calculates the trend of changes in intersection sizes using three types of fits:
+        linear, exponential, and quadratic polynomial. It then compares the residuals of these fits to determine
+        the best fitting model and classifies the trend based on the parameters of the best fit.
+
+        Returns:
+            IntersectionTrend: An enumeration value representing the classified trend:
+                - IntersectionTrend.DRASTIC: If the exponential fit is the best and the decay rate (beta) is greater than 0.8.
+                - IntersectionTrend.RAPID: If the exponential fit is the best but the decay rate (beta) is less than or equal to 0.8.
+                - IntersectionTrend.QUICK: If the quadratic polynomial fit is the best.
+                - IntersectionTrend.STEADY: If the linear fit is the best.
         """
         intersection_sizes = [self.data.subsets[i].size for i in range(len(self.data.subsets))]
 
         x = np.arange(len(intersection_sizes))
         y = np.array(intersection_sizes)
-        
-        try:
-            popt, _ = curve_fit(lambda x, a, b, c: a*np.exp(-b*x)+c, x, y, 
-                                p0=[max(y), 0.1, min(y)],
-                                bounds=([0, 0, 0], [np.inf, np.inf, np.inf]),
-                                maxfev=5000)
-            a, b, c = popt
-            
-            if b > 0 and a > 0:
-                x_fit = np.linspace(0, len(intersection_sizes)-1, 100)
-                y_fit = a * np.exp(-b * x_fit) + c
-                
-                if b > 0.5:
-                    return IntersectionTrend.DRASTIC.value
-                else:
-                    return IntersectionTrend.MODERATE.value
 
-        except:
-            pass  # If exponential fit fails, we'll fall back to linear regression
-      
-        slope, _, r_value, p_value, _ = stats.linregress(x, y)
-    
-        if p_value < 0.05: 
-            relative_change = abs(slope * (len(x) - 1) / y[0])
-            if relative_change > 0.5:
+        # linear fit
+        slope, intercept, r_value, p_value, _ = stats.linregress(x, y)
+        linear_fit = slope * x + intercept
+        linear_residuals = np.sum((y - linear_fit) ** 2)
+
+        # exponential fit
+        popt, _ = curve_fit(lambda x, a, beta, c: a*np.exp(-b*x)+c, x, y, 
+                            p0=[max(y), 0.1, min(y)],
+                            bounds=([0, 0, 0], [np.inf, np.inf, np.inf]),
+                            maxfev=5000)
+        a, beta, c = popt
+
+        if beta > 0 and a > 0:
+            x_fit = np.linspace(0, len(x)-1, 100)
+            y_fit = a * np.exp(-beta * x_fit) + c
+            y_fit_interpolated = np.interp(x, x_fit, y_fit)  # Interpolate y_fit to match x
+            exponential_residuals = np.sum((y - y_fit_interpolated) ** 2)
+        else:
+            exponential_residuals = np.inf
+
+        # polynomial fit
+        fit = np.polyfit(x, y, 2, full=True)
+        quadratic_residuals = fit[1][0]
+
+        if exponential_residuals < linear_residuals and exponential_residuals < quadratic_residuals:
+            if beta > 0.8:
                 return IntersectionTrend.DRASTIC.value
             else:
-                return IntersectionTrend.MODERATE.value
+                return IntersectionTrend.RAPID.value
+        elif quadratic_residuals < linear_residuals and quadratic_residuals < exponential_residuals:
+            return IntersectionTrend.QUICK.value
         else:
-            return IntersectionTrend.SLIGHT.value
-      
-        
+            return IntersectionTrend.STEADY.value
+
     def calculate_largest_factor(self):
         sorted_sizes = self.sort_subsets_by_key(SubsetField.SIZE, True)
         if len(sorted_sizes) >= 2:


### PR DESCRIPTION
### Does this PR close any open issues?
Closes none

### Give a longer description of what this PR addresses and why it's needed
This PR revises the intersection size trend analysis by performing a residual comparison between the three types of fits.
First, a standard linear regression fit is performed and residuals calculated. This represents a steady trend in intersection size. Then, a quadratic polynomial fit is calculated. This represents a moderate growth in sizes. Then, an exponential curve is fitted and a first line approximation is used to calculate residuals. $\beta$ is used as a threshold to determine the steepness of the growth via decay. Values of $\beta$ greater than 0.8 indicate drastic changes in size. $\beta$ <= 0.8 indicate a rapid change in sizes.

### Provide pictures/videos of the behavior before and after these changes (optional)
World Orgs: ($\beta$ = 1.383750)
The intersection sizes peak at a value of 143 and then drastically flatten down to 1. Unesco, Interpol, WHO, UN, and WTO is the largest by a factor of 4. The empty intersection is present with a size of 22. An all set intersection is not present. The individual set intersections are small in size. The low degree set intersections lie in medium sized intersections. The medium degree set intersections can be seen among small and medium sized intersections. In large and largest sized intersections, the high order set intersections are significantly present

![image](https://github.com/user-attachments/assets/c98b2870-f7d4-4b70-84b8-449eb119d68c)


Tennis: ($\beta$ = 0.262687)
The intersection sizes peak at a value of 23 and then rapidly flatten down to 1. An all set intersection is present with a size of 9. The individual set intersections are in large and largest intersections. The low degree set intersections lie in small and medium sized intersections. The medium degree set intersections can be seen among small sized intersections. Among the large sized intersections, the high order set intersections are significantly present.

![image](https://github.com/user-attachments/assets/3f1fe445-3933-4dde-abe5-67e4efbe0e6b)


Movies: ($\beta$ = 1.318176)
The intersection sizes peak at a value of 1371 and then drastically flatten down to 1. Just Drama is the largest by a factor of 4. An all set intersection is not present. The individual set intersections are in large and largest intersections. The low degree set intersections lie in small and medium sized intersections. The medium degree set intersections can be seen among small sized intersections. No high order intersections are present

![image](https://github.com/user-attachments/assets/20c61a20-9bc0-438d-a5ac-9202a77ce185)


Covid: ($\beta$ = 0.518944)
The intersection sizes peak at a value of 540 and then rapidly flatten down to 6. The empty intersection is present with a size of 57. An all set intersection is not present. The individual set intersections are in large and small intersections. The low degree set intersections lie in largest sized intersections. The medium degree set intersections can be seen among medium sized intersections. Among the small sized intersections, the high order set intersections are significantly present.

![image](https://github.com/user-attachments/assets/2ffedfe4-11cf-4433-acb1-cff7d65af2d4)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [X] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
